### PR TITLE
Add sixel_decode_raw_rgba, fix decoding of high-color SIXEL's

### DIFF
--- a/converters/img2sixel_tests.sh
+++ b/converters/img2sixel_tests.sh
@@ -1,8 +1,18 @@
 echo '[start]'
 
-test -z "$1"; HAVE_PNG=$?
-test -z "$2"; HAVE_CURL=$?
-test ! -z "$3"; BE_SILENT=$?
+response_code() { if [ $? -eq 0 ]; then echo 0; else echo 1; fi }
+
+if test ! -z "$1"; then
+    HAVE_PNG=true
+fi
+if test ! -z "$2"; then
+    HAVE_CURL=true
+fi
+if test ! -z "$3"; then
+    SILENT='> /dev/null'
+else
+    SILENT=''
+fi
 
 echo '[test1] invalid option handling'
 mkdir -p ${BUILDDIR}/tmp/
@@ -42,12 +52,6 @@ test ! $(echo -n a | ${BUILDDIR}/img2sixel)
 echo '[test3] print information'
 ${BUILDDIR}/img2sixel -H
 ${BUILDDIR}/img2sixel -V
-
-if [[ $BE_SILENT -eq 0 ]]; then
-    SILENT='> /dev/null'
-else
-    SILENT=''
-fi
 
 echo '[test4] conversion options'
 eval "${BUILDDIR}/img2sixel ${TOP_SRCDIR}/images/snake.jpg -datkinson -flum -saverage | ${BUILDDIR}/img2sixel | tee ${BUILDDIR}/tmp/snake.sixel $SILENT"
@@ -123,7 +127,7 @@ eval ${BUILDDIR}/img2sixel -S -datkinson ${TOP_SRCDIR}/images/seq2gif.gif $SILEN
 echo
 echo '[test8] progressive jpeg'
 eval ${BUILDDIR}/img2sixel ${TOP_SRCDIR}/images/snake-progressive.jpg $SILENT
-if test HAVE_PNG; then
+if test $HAVE_PNG; then
 echo
 echo '[test9] various PNG'
 eval ${BUILDDIR}/img2sixel ${TOP_SRCDIR}/images/pngsuite/basic/basn0g01.png $SILENT
@@ -190,7 +194,7 @@ eval ${BUILDDIR}/img2sixel -w32 -B\#fff ${TOP_SRCDIR}/images/pngsuite/background
 eval ${BUILDDIR}/img2sixel -w32 -B\#fff ${TOP_SRCDIR}/images/pngsuite/background/bgwn6a08.png $SILENT
 eval ${BUILDDIR}/img2sixel -w32 -B\#fff ${TOP_SRCDIR}/images/pngsuite/background/bgyn6a16.png $SILENT
 fi
-if test HAVE_CURL; then
+if test $HAVE_CURL; then
 echo
 echo '[test10] curl'
 test ! $(${BUILDDIR}/img2sixel file:///test)

--- a/include/sixel.h.in
+++ b/include/sixel.h.in
@@ -21,6 +21,7 @@
  */
 
 #include <stddef.h>  /* for size_t */
+#include <stdbool.h>
 
 #ifndef LIBSIXEL_SIXEL_H
 #define LIBSIXEL_SIXEL_H
@@ -802,11 +803,27 @@ sixel_encode(
     sixel_dither_t /* in */ *dither,     /* dither context */
     sixel_output_t /* in */ *context);   /* output context */
 
+typedef struct {
+    int          width;
+    int          height;
+    unsigned int ncolors;
+    bool         has_transparency;
+} sixel_info_t;
+
+SIXELAPI SIXELSTATUS
+sixel_decode_raw_rgba(
+    unsigned char     /* in */  *sixels,
+    unsigned int      /* in */  len,
+    unsigned char     /* out */ **pixels,
+    sixel_info_t      /* out */ *info,
+    sixel_allocator_t /* in */  *allocator
+);
+
 /* convert sixel data into indexed pixel bytes and palette data */
 SIXELAPI SIXELSTATUS
 sixel_decode_raw(
     unsigned char       /* in */  *p,           /* sixel bytes */
-    int                 /* in */  len,          /* size of sixel bytes */
+    unsigned int        /* in */  len,          /* size of sixel bytes */
     unsigned char       /* out */ **pixels,     /* decoded pixels */
     int                 /* out */ *pwidth,      /* image width */
     int                 /* out */ *pheight,     /* image height */
@@ -817,7 +834,7 @@ sixel_decode_raw(
 SIXELAPI __attribute__((deprecated)) SIXELSTATUS
 sixel_decode(
     unsigned char            /* in */  *sixels,    /* sixel bytes */
-    int                      /* in */  size,       /* size of sixel bytes */
+    unsigned int             /* in */  size,       /* size of sixel bytes */
     unsigned char            /* out */ **pixels,   /* decoded pixels */
     int                      /* out */ *pwidth,    /* image width */
     int                      /* out */ *pheight,   /* image height */
@@ -855,8 +872,30 @@ sixel_helper_compute_depth(
     int /* in */ pixelformat /* one of enum pixelFormat */
 );
 
+/* convert pixelFormat into PIXELFORMAT_RGBA8888 */
+SIXELAPI SIXELSTATUS
+sixel_helper_normalize_pixelformat_rgba(
+    unsigned char       /* out */ *dst,             /* destination buffer */
+    int                 /* out */ *dst_pixelformat, /* converted pixelformat */
+    unsigned char const /* in */  *src,             /* source pixels */
+    int                 /* in */  src_pixelformat,  /* format of source image */
+    int                 /* in */  width,            /* width of source image */
+    int                 /* in */  height            /* height of source image */
+);
+
 /* convert pixelFormat into PIXELFORMAT_RGB888 */
 SIXELAPI SIXELSTATUS
+sixel_helper_normalize_pixelformat_rgb(
+    unsigned char       /* out */ *dst,             /* destination buffer */
+    int                 /* out */ *dst_pixelformat, /* converted pixelformat */
+    unsigned char const /* in */  *src,             /* source pixels */
+    int                 /* in */  src_pixelformat,  /* format of source image */
+    int                 /* in */  width,            /* width of source image */
+    int                 /* in */  height            /* height of source image */
+);
+
+/* convert pixelFormat into PIXELFORMAT_RGB888 */
+SIXELAPI __attribute__((deprecated)) SIXELSTATUS
 sixel_helper_normalize_pixelformat(
     unsigned char       /* out */ *dst,             /* destination buffer */
     int                 /* out */ *dst_pixelformat, /* converted pixelformat */

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -217,15 +217,12 @@ sixel_decoder_decode(
 {
     SIXELSTATUS status = SIXEL_FALSE;
     unsigned char *raw_data = NULL;
-    int sx;
-    int sy;
-    int raw_len;
-    int max;
-    int n;
+    unsigned int raw_len;
+    unsigned int max;
+    unsigned int n;
     FILE *input_fp = NULL;
     unsigned char *indexed_pixels = NULL;
     unsigned char *palette = NULL;
-    int ncolors;
 
     sixel_decoder_ref(decoder);
 
@@ -271,7 +268,7 @@ sixel_decoder_decode(
                 goto end;
             }
         }
-        if ((n = (int)fread(raw_data + raw_len, 1, 4096, input_fp)) <= 0) {
+        if ((n = fread(raw_data + raw_len, 1, 4096, input_fp)) <= 0) {
             break;
         }
         raw_len += n;
@@ -281,28 +278,26 @@ sixel_decoder_decode(
         fclose(input_fp);
     }
 
-    status = sixel_decode_raw(
+    sixel_info_t info;
+
+    status = sixel_decode_raw_rgba(
         raw_data,
         raw_len,
         &indexed_pixels,
-        &sx,
-        &sy,
-        &palette,
-        &ncolors,
+        &info,
         decoder->allocator);
     if (SIXEL_FAILED(status)) {
         goto end;
     }
 
-    if (sx > SIXEL_WIDTH_LIMIT || sy > SIXEL_HEIGHT_LIMIT) {
+    if (info.width > SIXEL_WIDTH_LIMIT || info.height > SIXEL_HEIGHT_LIMIT) {
         status = SIXEL_BAD_INPUT;
         goto end;
     }
 
-    status = sixel_helper_write_image_file(indexed_pixels, sx, sy, palette,
-                                           SIXEL_PIXELFORMAT_PAL8,
-                                           decoder->output,
-                                           SIXEL_FORMAT_PNG,
+    status = sixel_helper_write_image_file(indexed_pixels, info.width, info.height,
+                                           palette, SIXEL_PIXELFORMAT_RGBA8888,
+                                           decoder->output, SIXEL_FORMAT_PNG,
                                            decoder->allocator);
 
     if (SIXEL_FAILED(status)) {

--- a/src/dither.c
+++ b/src/dither.c
@@ -547,7 +547,7 @@ sixel_dither_initialize(
             goto end;
         }
 
-        status = sixel_helper_normalize_pixelformat(
+        status = sixel_helper_normalize_pixelformat_rgb(
             normalized_pixels,
             &pixelformat,
             data,
@@ -777,10 +777,10 @@ sixel_dither_apply_palette(
             status = SIXEL_BAD_ALLOCATION;
             goto end;
         }
-        status = sixel_helper_normalize_pixelformat(normalized_pixels,
-                                                    &dither->pixelformat,
-                                                    pixels, dither->pixelformat,
-                                                    width, height);
+        status = sixel_helper_normalize_pixelformat_rgb(normalized_pixels,
+                                                        &dither->pixelformat,
+                                                        pixels, dither->pixelformat,
+                                                        width, height);
         if (SIXEL_FAILED(status)) {
             goto end;
         }

--- a/src/frame.c
+++ b/src/frame.c
@@ -415,12 +415,12 @@ sixel_frame_convert_to_rgb888(sixel_frame_t /*in */ *frame)
         }
         src = normalized_pixels + frame->width * frame->height * 3;
         dst = normalized_pixels;
-        status = sixel_helper_normalize_pixelformat(src,
-                                                    &frame->pixelformat,
-                                                    frame->pixels,
-                                                    frame->pixelformat,
-                                                    frame->width,
-                                                    frame->height);
+        status = sixel_helper_normalize_pixelformat_rgb(src,
+                                                        &frame->pixelformat,
+                                                        frame->pixels,
+                                                        frame->pixelformat,
+                                                        frame->width,
+                                                        frame->height);
         if (SIXEL_FAILED(status)) {
             sixel_allocator_free(frame->allocator, normalized_pixels);
             goto end;
@@ -474,12 +474,12 @@ sixel_frame_convert_to_rgb888(sixel_frame_t /*in */ *frame)
             status = SIXEL_BAD_ALLOCATION;
             goto end;
         }
-        status = sixel_helper_normalize_pixelformat(normalized_pixels,
-                                                    &frame->pixelformat,
-                                                    frame->pixels,
-                                                    frame->pixelformat,
-                                                    frame->width,
-                                                    frame->height);
+        status = sixel_helper_normalize_pixelformat_rgb(normalized_pixels,
+                                                        &frame->pixelformat,
+                                                        frame->pixels,
+                                                        frame->pixelformat,
+                                                        frame->width,
+                                                        frame->height);
         if (SIXEL_FAILED(status)) {
             sixel_allocator_free(frame->allocator, normalized_pixels);
             goto end;
@@ -701,12 +701,12 @@ sixel_frame_clip(
     case SIXEL_PIXELFORMAT_G4:
         normalized_pixels = (unsigned char *)sixel_allocator_malloc(frame->allocator,
                                                                     (size_t)(frame->width * frame->height));
-        status = sixel_helper_normalize_pixelformat(normalized_pixels,
-                                                    &frame->pixelformat,
-                                                    frame->pixels,
-                                                    frame->pixelformat,
-                                                    frame->width,
-                                                    frame->height);
+        status = sixel_helper_normalize_pixelformat_rgb(normalized_pixels,
+                                                        &frame->pixelformat,
+                                                        frame->pixels,
+                                                        frame->pixelformat,
+                                                        frame->width,
+                                                        frame->height);
         if (SIXEL_FAILED(status)) {
             sixel_allocator_free(frame->allocator, normalized_pixels);
             goto end;

--- a/src/loader.c
+++ b/src/loader.c
@@ -276,6 +276,7 @@ load_png(unsigned char      /* out */ **result,
     png_color_16p default_background;
     int i;
     int depth;
+    int number_of_passes;
 
     if (setjmp(jmpbuf) != 0) {
         sixel_allocator_free(allocator, *result);
@@ -324,6 +325,7 @@ load_png(unsigned char      /* out */ **result,
     read_chunk.size = size;
 
     png_set_read_fn(png_ptr,(png_voidp)&read_chunk, read_png);
+    number_of_passes = png_set_interlace_handling(png_ptr);
     png_read_info(png_ptr, info_ptr);
     *psx = (int)png_get_image_width(png_ptr, info_ptr);
     *psy = (int)png_get_image_height(png_ptr, info_ptr);
@@ -607,7 +609,7 @@ cleanup:
 static SIXELSTATUS
 load_sixel(unsigned char        /* out */ **result,
            unsigned char        /* in */  *buffer,
-           int                  /* in */  size,
+           unsigned int         /* in */  size,
            int                  /* out */ *psx,
            int                  /* out */ *psy,
            unsigned char        /* out */ **ppalette,
@@ -794,7 +796,7 @@ load_with_builtin(
         }
         status = load_sixel(&frame->pixels,
                             pchunk->buffer,
-                            (int)pchunk->size,
+                            pchunk->size,
                             &frame->width,
                             &frame->height,
                             fuse_palette ? &frame->palette: NULL,
@@ -987,6 +989,7 @@ load_with_gdkpixbuf(
     if (!animation || fstatic || gdk_pixbuf_animation_is_static_image(animation)) {
         pixbuf = gdk_pixbuf_loader_get_pixbuf(loader);
         if (pixbuf == NULL) {
+            status = SIXEL_FALSE; // because reset by sixel_frame_new
             goto end;
         }
         frame->frame_no = 0;

--- a/src/scale.c
+++ b/src/scale.c
@@ -325,10 +325,10 @@ sixel_helper_scale_image(
         if (new_src == NULL) {
             return (-1);
         }
-        nret = sixel_helper_normalize_pixelformat(new_src,
-                                                  &new_pixelformat,
-                                                  src, pixelformat,
-                                                  srcw, srch);
+        nret = sixel_helper_normalize_pixelformat_rgb(new_src,
+                                                    &new_pixelformat,
+                                                    src, pixelformat,
+                                                    srcw, srch);
         if (nret != 0) {
             sixel_allocator_free(allocator, new_src);
             return (-1);

--- a/src/tosixel.c
+++ b/src/tosixel.c
@@ -906,11 +906,11 @@ sixel_encode_dither(
             status = SIXEL_BAD_ALLOCATION;
             goto end;
         }
-        status = sixel_helper_normalize_pixelformat(paletted_pixels,
-                                                    &dither->pixelformat,
-                                                    pixels,
-                                                    dither->pixelformat,
-                                                    width, height);
+        status = sixel_helper_normalize_pixelformat_rgb(paletted_pixels,
+                                                        &dither->pixelformat,
+                                                        pixels,
+                                                        dither->pixelformat,
+                                                        width, height);
         if (SIXEL_FAILED(status)) {
             goto end;
         }
@@ -1447,11 +1447,11 @@ sixel_encode_highcolor(
         if (normalized_pixels == NULL) {
             goto error;
         }
-        status = sixel_helper_normalize_pixelformat(normalized_pixels,
-                                                    &dither->pixelformat,
-                                                    pixels,
-                                                    dither->pixelformat,
-                                                    width, height);
+        status = sixel_helper_normalize_pixelformat_rgb(normalized_pixels,
+                                                        &dither->pixelformat,
+                                                        pixels,
+                                                        dither->pixelformat,
+                                                        width, height);
         if (SIXEL_FAILED(status)) {
             goto error;
         }


### PR DESCRIPTION
Closes #15.
Closes #16.
Closes saitoha#149.
Closes saitoha#28.
Closes saitoha#61.

This PR fixes both problems at once. It does so by adding a new decode
function, and using it by default in `img2sixel`.

This function returns to the user RGBA data instead of palette'd data.
This sidesteps the many issues I found when considering raising the
maximum size of a palette to 255*255*255*255. For one thing, I already
knew I needed at some point for Kitty project something like this so I
wouldn't need to allocate my own, which is needless effort when the
decoder can do it.

This is ready for review. @dankamongmen may have time. I'll leave it for
a while as I go back to working on Kitty. If no one has time to review,
I'll merge it in ~4 days or so.